### PR TITLE
Correction de l'exemple de Buzz dans la section 10.1.1.3 Kata pour FizzBuzz

### DIFF
--- a/TDD.qmd
+++ b/TDD.qmd
@@ -153,5 +153,5 @@ Il s'agit de créer une classe ayant une méthode acceptant un entier et retourn
 9. Supporter des exigences qui évoluent. Attention aux conflits dans les exigences:
 
     a. Il faut imprimer Fizz au lieu du nombre si le nombre est un multiple de 3 ou contient un 3 (ex.: 13 → `Fizz`).
-    b. Il faut imprimer Buzz au lieu du nombre si le nombre est un multiple de 5 ou contient un 5 (ex.: 59 → `Fizz`).
+    b. Il faut imprimer Buzz au lieu du nombre si le nombre est un multiple de 5 ou contient un 5 (ex.: 59 → `Buzz`).
     c. Il faut imprimer FizzBuzz si le nombre est un multiple de 5 et de 3 ou contient un 5 et un 3 (ex.: 53 → `FizzBuzz`).


### PR DESCRIPTION
Correction de l'exemple de Buzz pour les multiples de 5 et les nombres contenant 5.

![image](https://github.com/fuhrmanator/log210-ndc-quarto/assets/2374739/85584db1-4741-4335-acde-c8fbb3195c3d)
