### PR TITLE
Clarification des exigences pour Kata FizzBuzz

### DIFF
--- a/TDD.qmd
+++ b/TDD.qmd
@@ -140,7 +140,7 @@ Pour respecter la philosophie de *petits pas,* il vaut mieux:
 #### Kata pour FizzBuzz
 
 Les étapes sont simples et précises.
-Il s'agit de créer une classe ayant une méthode acceptant un entier et retournant une valeur selon les exigences de FizzBuzz décrites plus haut.
+Il s'agit de créer une classe ayant une méthode acceptant un entier et retournant une valeur selon les exigences de FizzBuzz décrites plus haut, tout en supportant de nouvelles exigences (point 9) dans le cas où un nombre contient un chiffre particulier.
 
 1. Un argument de 1 retourne `1`.
 2. Un argument de 2 retourne `2`.


### PR DESCRIPTION
Des étudiants se sont plaints d'avoir perdu des points pour le pas avoir respecter les exigences suivantes:

> 9. Supporter des exigences qui évoluent. Attention aux conflits dans les exigences:
> 
>     a. Il faut imprimer Fizz au lieu du nombre si le nombre est un multiple de 3 ou contient un 3 (ex.: 13 → `Fizz`).
>     b. Il faut imprimer Buzz au lieu du nombre si le nombre est un multiple de 5 ou contient un 5 (ex.: 59 → `Buzz`).
>     c. Il faut imprimer FizzBuzz si le nombre est un multiple de 5 et de 3 ou contient un 5 et un 3 (ex.: 53 → `FizzBuzz`).

J'ai donc modifié une phrase pour spécifier que ce n'est pas seulement les exigences "décrites plus haut" qui doivent être respectées.
